### PR TITLE
chore: improve logging and tracing

### DIFF
--- a/src/function_blueprints/http_check_task_status.py
+++ b/src/function_blueprints/http_check_task_status.py
@@ -2,6 +2,7 @@ import azure.functions as func
 from src.specs.http.check_task_status import TaskStatusResponse
 from src.specs.common.ids import RunRef
 from src.shared.state import RunStateStore
+from src.shared.logging_utils import info as log_info, error as log_error
 
 
 bp = func.Blueprint()
@@ -15,14 +16,19 @@ def check_task_status(req: func.HttpRequest) -> func.HttpResponse:
         try:
             body = req.get_json()
             run_trace_id = body.get("runTraceId") if isinstance(body, dict) else None
-        except Exception:
+        except Exception as exc:
+            log_error(None, "status:bad_json", error=str(exc))
             run_trace_id = None
 
+    log_info(run_trace_id, "status:request")
+
     if not run_trace_id:
+        log_error(None, "status:missing_runTraceId")
         return func.HttpResponse("Missing runTraceId", status_code=400)
 
     state = RunStateStore.get_status(run_trace_id)
     if state is None:
+        log_info(run_trace_id, "status:not_found")
         # Not found yet; treat as pending orchestrate
         resp = TaskStatusResponse(
             runTraceId=run_trace_id,
@@ -33,6 +39,7 @@ def check_task_status(req: func.HttpRequest) -> func.HttpResponse:
             summary=None,
         )
     else:
+        log_info(run_trace_id, "status:found", phase=state.get("currentPhase"), status=state.get("status"))
         resp = TaskStatusResponse(**state)
 
     return func.HttpResponse(


### PR DESCRIPTION
## Summary
- add error logging and duration metrics to orchestrate HTTP entrypoint
- emit queue dequeue events, durations, and RunStateStore error logs across content, image, and publish workers
- log status polling requests and missing IDs

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68afb23e29b88320bc206fcd4ad4a619