### PR TITLE
feat: add planning orchestrator and base agent

### DIFF
--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class Agent(ABC):
+    """Abstract base class for all agents.
+
+    Provides a standard ``run`` interface and support for attaching a
+    ``run_trace_id`` used for logging or state tracking.
+    """
+
+    def __init__(self) -> None:
+        self._run_trace_id: str | None = None
+
+    def with_run_trace(self, run_trace_id: str) -> "Agent":
+        """Attach a runTraceId for downstream logging."""
+
+        self._run_trace_id = run_trace_id
+        return self
+
+    @abstractmethod
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        """Execute the agent and return its structured output."""
+
+
+__all__ = ["Agent"]

--- a/src/agents/copywriter_agent_foundry.py
+++ b/src/agents/copywriter_agent_foundry.py
@@ -22,9 +22,10 @@ from src.tools.get_brand_tool import FUNCTION_TOOL as BRAND_TOOL, call_function_
 from src.tools.get_post_plan_tool import FUNCTION_TOOL as PLAN_TOOL, call_function_tool as call_plan
 from src.shared.logging_utils import info as log_info
 from src.shared.retry_utils import retry_with_backoff
+from .base import Agent
 
 
-class FoundryCopywriterAgent:
+class FoundryCopywriterAgent(Agent):
     """Copywriter agent using Azure AI Foundry Agents SDK (AIProjectClient).
 
     Registers function tools (get_brand, get_post_plan), runs the agent, handles
@@ -33,6 +34,7 @@ class FoundryCopywriterAgent:
     """
 
     def __init__(self, *, model: Optional[str] = None) -> None:
+        super().__init__()
         if AIProjectClient is None or DefaultAzureCredential is None:
             raise RuntimeError(
                 "Azure AI Foundry Agents SDK not available. Install 'azure-ai-projects' and 'azure-identity'."

--- a/src/agents/image_agent_foundry.py
+++ b/src/agents/image_agent_foundry.py
@@ -17,9 +17,10 @@ from src.tools.get_post_plan_tool import FUNCTION_TOOL as PLAN_TOOL, call_functi
 from src.tools.search_images_tool import FUNCTION_TOOL as SEARCH_TOOL, call_function_tool as call_search
 from src.tools.image_creation_tools import FUNCTION_TOOLS as IMG_TOOLS, call_function_tool as call_img_tool
 from src.shared.retry_utils import retry_with_backoff
+from .base import Agent
 
 
-class FoundryImageAgent:
+class FoundryImageAgent(Agent):
     """Agent that selects the best image for a post.
 
     - Can search the web for candidate images
@@ -29,6 +30,7 @@ class FoundryImageAgent:
     """
 
     def __init__(self, *, model: Optional[str] = None) -> None:
+        super().__init__()
         if AIProjectClient is None or DefaultAzureCredential is None:
             raise RuntimeError(
                 "Azure AI Foundry Agents SDK not available. Install 'azure-ai-projects' and 'azure-identity'."

--- a/src/function_blueprints/agent_tasks.py
+++ b/src/function_blueprints/agent_tasks.py
@@ -9,6 +9,7 @@ from src.specs.agents.image import ImageAgentInput
 from src.specs.agents.publish import PublishInput, PublishOutput
 from src.shared.cosmos_utils import get_cosmos_container
 from src.shared.logging_utils import info as log_info, error as log_error
+from src.tools.get_post_plan_tool import get_post_plan
 
 
 def generate_content_with_agent(run_trace_id: str, brand_id: str, post_plan_id: str) -> dict:
@@ -86,6 +87,30 @@ def generate_image_via_agent(
         "url": out.url,
         "provider": getattr(out, "provider", None),
     }
+
+
+def load_post_plan(*, brand_id: str, post_plan_id: str) -> dict:
+    """Fetch the post plan document to drive orchestration decisions."""
+
+    resp = get_post_plan(brand_id, post_plan_id)
+    return resp.document or {}
+
+
+def post_to_channel(channel: str, publish: PublishInput) -> dict:
+    """Stub for posting to a specific social media channel.
+
+    A real implementation would call the platform API. For now we log and
+    return a simple status payload.
+    """
+
+    log_info(
+        publish.runTraceId,
+        "social:post",  # event name
+        channel=channel,
+        brandId=publish.brandId,
+        postPlanId=publish.postPlanId,
+    )
+    return {"channel": channel, "status": "posted"}
 
 
 def persist_publish(data: PublishInput) -> PublishOutput:


### PR DESCRIPTION
## Summary
- add abstract Agent base class and update copywriter and image agents to inherit
- add planning step to durable orchestration with conditional media and parallel channel posting
- stub channel posting activity and helper utilities

## Testing
- `pytest`
- `python -m py_compile src/agents/base.py src/agents/copywriter_agent_foundry.py src/agents/image_agent_foundry.py src/function_blueprints/agent_tasks.py src/function_blueprints/durable_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0e51cbba083208e8e656b1477bc53